### PR TITLE
Rate forms with additional tags a bit lower during inflection. Fixes Issue #64

### DIFF
--- a/pymorphy2/analyzer.py
+++ b/pymorphy2/analyzer.py
@@ -361,7 +361,7 @@ class MorphAnalyzer(object):
         grammemes = form[1].updated_grammemes(required_grammemes)
         def similarity(frm):
             tag = frm[1]
-            return len(grammemes & tag.grammemes)
+            return len(grammemes & tag.grammemes) - 0.1 * len(grammemes ^ tag.grammemes)
 
         return heapq.nlargest(1, possible_results, key=similarity)
 

--- a/tests/test_inflection.py
+++ b/tests/test_inflection.py
@@ -101,3 +101,11 @@ def test_case_substitution(word, grammemes, result, morph):
 ])
 def test_best_guess(word, grammemes, result, morph):
     assert_first_inflected_variant(word, grammemes, result, morph)
+
+
+@with_test_data([
+    ('заснеженный', ['gent'], 'заснеженного'),  # не "заснежённого"
+    ('ведро', ['gent'], 'ведра'),  # не "вёдра"
+])
+def test_not_informal(word, grammemes, result, morph):
+    assert_first_inflected_variant(word, grammemes, result, morph)


### PR DESCRIPTION
Rate forms with additional tags (eg. with 'Infr' tag) a bit lower during inflection. Fixes Issue #64

Исправление для issue #64. За полгода работы с вариантом процедуры, показанном в комментариях к issue, могу сказать, что все работает нормально, и более логично, чем с дефолтным методом `.inflect()`