### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ for Russian and Ukrainian languages. License is MIT.
 .. image:: https://coveralls.io/repos/kmike/pymorphy2/badge.svg?branch=master
     :target: https://coveralls.io/r/kmike/pymorphy2?branch=master
 
-* docs: https://pymorphy2.readthedocs.org
+* docs: https://pymorphy2.readthedocs.io
 * changelog: https://github.com/kmike/pymorphy2/blob/master/CHANGES.rst
 * source code: github_
 * bug tracker: https://github.com/kmike/pymorphy2/issues

--- a/docs/internals/dict.rst
+++ b/docs/internals/dict.rst
@@ -470,5 +470,5 @@ DAWG достаточно эффективная. Хранение слов в D
 "съедят" эту разницу (особенно при использовании из питоньего кода).
 
 .. _mystem: http://company.yandex.ru/technologies/mystem/
-.. _pymorphy 0.5.6: http://pymorphy.readthedocs.org/en/v0.5.6/index.html
+.. _pymorphy 0.5.6: https://pymorphy.readthedocs.io/en/v0.5.6/index.html
 .. _MAnalyzer: https://github.com/Melkogotto/MAnalyzer

--- a/docs/internals/prediction.rst
+++ b/docs/internals/prediction.rst
@@ -14,7 +14,7 @@
     `aot.ru <http://aot.ru>`_, и на те, что применяются в pymorphy1_,
     но отличаются в деталях и содержат дополнительные эвристики.
 
-.. _pymorphy1: http://pymorphy.readthedocs.org/en/latest/algo.html#prediction-algo
+.. _pymorphy1: https://pymorphy.readthedocs.io/en/latest/algo.html#prediction-algo
 
 
 Отсечение известных префиксов

--- a/docs/misc/2trie.rst
+++ b/docs/misc/2trie.rst
@@ -284,4 +284,4 @@ set() довольно велики::
     Длины хранятся 2 раза. Может, это можно как-то улучшить?
 
 .. _mystem: http://company.yandex.ru/technologies/mystem/
-.. _pymorphy 0.5.6: http://pymorphy.readthedocs.org/en/v0.5.6/index.html
+.. _pymorphy 0.5.6: https://pymorphy.readthedocs.io/en/v0.5.6/index.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.