### PR TITLE
Test fixes for Python 3.7 and 3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,pypy,pypy3}-{fast,slow},docs
+envlist = {py27,py34,py35,py36,py37,py38,pypy,pypy3}-{fast,slow},docs
 minversion = 2.1.1
 skip_missing_interpreters = True
 
@@ -8,6 +8,7 @@ deps=
     pytest
     pytest-cov
     tqdm
+    dawg >= 0.8.0
 
     pypy3: coverage < 4.0
     py27,py34,py35,py36,pypy: coverage >= 4.0
@@ -15,7 +16,8 @@ deps=
     py27,py34,py35,py36,pypy: psutil
     py27,pypy: futures
 
-    {py27,py34,py35,py36}-fast: lxml
+    {py27,py35,py36}-fast: lxml
+    py34-fast: lxml == 4.3.5
 
     ; keep support for pymorphy2==0.8 dictionaries
     slow: pymorphy2-dicts==2.4.393442.3710985


### PR DESCRIPTION
Package works for 3.8, but tests need requirements update