### PR TITLE
docs: fix simple typo, initialzed -> initialized

### DIFF
--- a/pymorphy2/tagset.py
+++ b/pymorphy2/tagset.py
@@ -72,7 +72,7 @@ class OpencorporaTag(object):
 
         >>> from pymorphy2 import MorphAnalyzer
         >>> morph = MorphAnalyzer()
-        >>> Tag = morph.TagClass  # get an initialzed Tag class
+        >>> Tag = morph.TagClass  # get an initialized Tag class
         >>> tag = Tag('VERB,perf,tran plur,impr,excl')
         >>> tag
         OpencorporaTag('VERB,perf,tran plur,impr,excl')


### PR DESCRIPTION
There is a small typo in pymorphy2/tagset.py.

Should read `initialized` rather than `initialzed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md